### PR TITLE
GROW-2569-Upgrading Flysystem Google Cloud Storage version required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"league/flysystem-rackspace": "~1.0",
 		"league/flysystem-aws-s3-v3": "~1.0",
 		"league/flysystem-cached-adapter": "~1.0",
-		"superbalist/flysystem-google-storage": "~1.0"
+		"superbalist/flysystem-google-storage": "~7.2.2"
 
 	},
 	"autoload": {


### PR DESCRIPTION
https://citymob.atlassian.net/browse/GROW-2569
Upgraded required in composer.json to version 7.2.2